### PR TITLE
Update kosyncsrv.go: Fix cmdline args.

### DIFF
--- a/kosyncsrv.go
+++ b/kosyncsrv.go
@@ -113,7 +113,6 @@ func updateProgress(c *gin.Context) {
 
 func main() {
 	dbfile := flag.String("d", "syncdata.db", "Sqlite3 DB file name")
-	dbname = *dbfile
 	srvhost := flag.String("t", "127.0.0.1", "Server host")
 	srvport := flag.Int("p", 8080, "Server port")
 	sslswitch := flag.Bool("ssl", false, "Start with https")
@@ -125,7 +124,10 @@ func main() {
 		flag.PrintDefaults()
 	}
 	flag.Parse()
+	
 	bindsrv := *srvhost + ":" + fmt.Sprint(*srvport)
+	
+	dbname = *dbfile
 	initDB()
 
 	router := gin.Default()

--- a/kosyncsrv.go
+++ b/kosyncsrv.go
@@ -119,12 +119,13 @@ func main() {
 	sslswitch := flag.Bool("ssl", false, "Start with https")
 	sslc := flag.String("c", "", "SSL Certificate file")
 	sslk := flag.String("k", "", "SSL Private key file")
-	bindsrv := *srvhost + ":" + fmt.Sprint(*srvport)
+	
 	flag.Usage = func() {
 		fmt.Println(`Usage: kosyncsrv [-h] [-t 127.0.0.1] [-p 8080] [-ssl -c "./cert.pem" -k "./cert.key"]`)
 		flag.PrintDefaults()
 	}
 	flag.Parse()
+	bindsrv := *srvhost + ":" + fmt.Sprint(*srvport)
 	initDB()
 
 	router := gin.Default()


### PR DESCRIPTION
Use cmd args after they have been parsed.